### PR TITLE
feat: add llm:compile-error for validating LLM-generated NetLogo code

### DIFF
--- a/demos/code-validation/README.md
+++ b/demos/code-validation/README.md
@@ -1,0 +1,88 @@
+# Code Validation
+
+A demonstration of `llm:compile-error` — the gate that makes the "LLM writes NetLogo code,
+the model runs it" pattern safe enough to put in front of students.
+
+**No API key required.** The candidate rules are a fixed pool, so this demo runs offline.
+
+## The Problem
+
+Several patterns in this repo have a model generate NetLogo code that the simulation then
+executes (`demos/templates/code-evolution-template.yaml`, `movement-evolution.yaml`).
+Generated code goes straight to `run`, and it cannot be trusted in two distinct ways:
+
+1. **It may not compile.** Invalid code throws mid-tick, killing the run.
+2. **It may compile and still be unwanted.** `die` in a generated agent rule kills the
+   population; `clear-all` wipes the experiment. Compiling is not the same as safe.
+
+`llm:compile-error` closes both. It reports `""` when code is acceptable, and otherwise
+the reason it was refused.
+
+## How It Works
+
+Every tick, each turtle draws a candidate rule from a pool and passes it through the gate:
+
+```netlogo
+to-report acceptable? [code]
+  let verdict (llm:compile-error code banned-primitives)
+  ...
+end
+```
+
+Turtles whose candidate passes adopt the new rule and turn **green**. Turtles whose
+candidate is refused keep their previous rule and turn **red**.
+
+The candidate pool deliberately mixes three kinds of code, so both failure modes are
+visible on every run:
+
+| Candidate | Verdict |
+|---|---|
+| `fd 1` | passes |
+| `rt random 30 fd 1` | passes |
+| `ifelse random 2 = 0 [ lt 10 fd 1 ] [ rt 10 fd 1 ]` | passes |
+| `frobnicate 1` | fails — no such primitive |
+| `ifelse xcor > 0 [ fd 1 ]` | fails — missing second block |
+| `die` | compiles, refused — banned |
+| `ask turtles [ fd 1 ]` | compiles, refused — banned |
+
+## How to Run
+
+1. Build and install the extension: `./build.sh` from the repo root.
+2. Open `code-validation.nlogox` in NetLogo 7.0.3.
+3. Press **setup**, then **go**. Watch the accepted/rejected monitors diverge.
+4. Press **check all rules** to print the gate's verdict on every candidate.
+
+## Things to Notice
+
+- Compile failures report a **character offset**, so a model can point at where the
+  generated code went wrong.
+- `die` and `ask turtles [ fd 1 ]` compile perfectly well and are still refused. This is
+  the case an external syntax checker cannot cover.
+- Matching is **token-based**, not substring. `die` inside a comment, inside a string
+  literal, or inside a longer identifier such as `diehard` does not trigger a false
+  positive — each of those would otherwise discard code that was valid.
+- The banned list lives in NetLogo (`banned-primitives`), not in the extension. What
+  counts as dangerous is model-specific, so the policy can change without a rebuild.
+
+## Making It Live
+
+Replace `candidate-rules` with a call to `llm:chat`:
+
+```netlogo
+to-report candidate-rules
+  report (list llm:chat "Write one line of NetLogo commands to move this turtle.")
+end
+```
+
+The gate does not change. That is the point of it.
+
+## Scope
+
+This proves the code **compiles**, not that it cannot fail at runtime. Bounds errors such
+as `item 3` on a three-element list still surface only during execution, so keep
+`carefully` around `run`.
+
+## Related
+
+- API reference: `docs/API-REFERENCE.md` → Code Validation
+- Issue [#52](https://github.com/NetLogo/Netlogo-LLM-Extension/issues/52)

--- a/demos/code-validation/code-validation.nlogox
+++ b/demos/code-validation/code-validation.nlogox
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="utf-8"?>
+<model version="NetLogo 7.0.3" snapToGrid="true">
+  <code><![CDATA[extensions [llm]
+
+globals [
+  banned-primitives  ;; primitives generated code is not allowed to use
+  rejected-count     ;; rules refused by the gate this run
+  accepted-count     ;; rules that passed the gate and ran
+  last-verdict       ;; the gate's message for the most recent rule
+]
+
+turtles-own [
+  rule  ;; the NetLogo command string this turtle moves by
+]
+
+to setup
+  clear-all
+  set banned-primitives ["die" "clear-all" "hatch" "ask"]
+  set rejected-count 0
+  set accepted-count 0
+  set last-verdict ""
+  create-turtles 40 [
+    setxy random-xcor random-ycor
+    set color sky
+    set rule "fd 1"
+  ]
+  reset-ticks
+end
+
+;; Try to give every turtle a new rule drawn from the candidate pool.
+;; The gate decides which ones are allowed to take effect.
+to go
+  ask turtles [
+    let candidate one-of candidate-rules
+    ifelse acceptable? candidate
+      [ set rule candidate
+        set color green ]
+      [ set color red ]
+  ]
+  ask turtles [ run rule ]
+  tick
+end
+
+;; The gate. Empty string means the code compiles AND uses no banned primitive.
+to-report acceptable? [code]
+  let verdict (llm:compile-error code banned-primitives)
+  set last-verdict verdict
+  ifelse verdict = ""
+    [ set accepted-count accepted-count + 1
+      report true ]
+    [ set rejected-count rejected-count + 1
+      report false ]
+end
+
+;; Stand-ins for model output: some valid, some malformed, some hostile.
+;; Swapping this for llm:chat is the only change needed to make it live.
+to-report candidate-rules
+  report (list
+    "fd 1"
+    "rt random 30 fd 1"
+    "ifelse random 2 = 0 [ lt 10 fd 1 ] [ rt 10 fd 1 ]"
+    "frobnicate 1"
+    "ifelse xcor > 0 [ fd 1 ]"
+    "die"
+    "ask turtles [ fd 1 ]"
+  )
+end
+
+;; Reports the gate's verdict on each candidate, for the output widget.
+to check-all
+  clear-output
+  foreach candidate-rules [ candidate ->
+    let verdict (llm:compile-error candidate banned-primitives)
+    ifelse verdict = ""
+      [ output-print (word "PASS  " candidate) ]
+      [ output-print (word "FAIL  " candidate)
+        output-print (word "      -> " verdict) ]
+  ]
+end
+]]></code>
+  <widgets>
+    <view x="420" y="10" width="514" height="514"
+          minPxcor="-16" maxPxcor="16" minPycor="-16" maxPycor="16"
+          patchSize="15.0" frameRate="30.0" fontSize="10"
+          wrappingAllowedX="true" wrappingAllowedY="true"
+          showTickCounter="true" tickCounterLabel="ticks" updateMode="1"/>
+    <button x="15" y="15" width="90" height="40" kind="Observer" display="setup" forever="false" disableUntilTicks="false">setup</button>
+    <button x="115" y="15" width="90" height="40" kind="Observer" display="go" forever="true" disableUntilTicks="true">go</button>
+    <button x="215" y="15" width="120" height="40" kind="Observer" display="check all rules" forever="false" disableUntilTicks="false">check-all</button>
+    <monitor x="15" y="70" width="150" height="50" display="accepted" precision="0" fontSize="11">accepted-count</monitor>
+    <monitor x="185" y="70" width="150" height="50" display="rejected" precision="0" fontSize="11">rejected-count</monitor>
+    <output x="15" y="135" width="390" height="250" fontSize="11"/>
+    <note x="15" y="395" width="390" height="120" fontSize="11" backgroundDark="0" backgroundLight="0" textColorDark="-1" textColorLight="-16777216" markdown="false">Green turtles took a new rule that passed the gate. Red turtles kept their old rule because the candidate failed to compile or used a banned primitive.
+
+Click "check all rules" to see the gate's verdict on every candidate.</note>
+  </widgets>
+  <info><![CDATA[## WHAT IS IT?
+
+A demonstration of `llm:compile-error`, the gate that makes the "LLM writes NetLogo code,
+the model runs it" pattern safe enough to put in front of students.
+
+Generated code cannot be trusted. A model may emit code that does not compile, or code that
+compiles but does something destructive such as `die` or `clear-all`. Without a gate, invalid
+code throws mid-tick and destructive code runs unchallenged.
+
+## HOW IT WORKS
+
+Every tick, each turtle draws a candidate rule from a pool and passes it through the gate:
+
+    llm:compile-error code banned-primitives
+
+The reporter returns an empty string when the code is acceptable. Any other string is the
+reason it was refused. Turtles that accept a new rule turn green; turtles whose candidate was
+refused keep their previous rule and turn red.
+
+The candidate pool mixes valid rules, malformed rules, and rules using banned primitives, so
+both failure modes are visible on every run.
+
+## HOW TO USE IT
+
+1. Press **setup**, then **go**.
+2. Watch the accepted and rejected monitors diverge.
+3. Press **check all rules** to print the gate's verdict on each candidate.
+
+## THINGS TO NOTICE
+
+`frobnicate 1` and `ifelse xcor > 0 [ fd 1 ]` fail compilation — one names a primitive that
+does not exist, the other is missing its second block. The verdict includes a character offset.
+
+`die` and `ask turtles [ fd 1 ]` compile perfectly well but are refused because they appear in
+the banned list. Compilation alone is not enough.
+
+Matching is exact and token-based, so `die` inside a comment, inside a string, or inside a
+longer identifier such as `diehard` does not trigger a false positive.
+
+## EXTENDING THE MODEL
+
+Replace `candidate-rules` with a call to `llm:chat` and the model becomes live. The gate does
+not change — that is the point of it.
+
+Note that the gate proves the code COMPILES, not that it cannot throw at runtime. Bounds errors
+such as `item 3` on a three-element list still surface only when the code runs, so keep
+`carefully` around execution.
+
+## RELATED PRIMITIVES
+
+`llm:compile-error` — validates code, optionally against a banned-primitive list
+]]></info>
+  <turtleShapes>
+    <shape name="default" rotatable="true" editableColorIndex="0">
+      <polygon color="-1920102913" filled="true" marked="true">
+        <point x="150" y="5"/>
+        <point x="40" y="250"/>
+        <point x="150" y="205"/>
+        <point x="260" y="250"/>
+      </polygon>
+    </shape>
+  </turtleShapes>
+  <linkShapes>
+    <shape name="default" curviness="0.0">
+      <lines>
+        <line x="-0.2" visible="false"><dash value="0.0"/><dash value="1.0"/></line>
+        <line x="0.0" visible="true"><dash value="1.0"/><dash value="0.0"/></line>
+        <line x="0.2" visible="false"><dash value="0.0"/><dash value="1.0"/></line>
+      </lines>
+      <indicator>
+        <shape name="link direction" rotatable="true" editableColorIndex="0">
+          <line startX="150" startY="150" endX="90" endY="180" marked="true" color="-1920102913"/>
+          <line startX="150" startY="150" endX="210" endY="180" marked="true" color="-1920102913"/>
+        </shape>
+      </indicator>
+    </shape>
+  </linkShapes>
+</model>

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -236,6 +236,59 @@ set color read-from-string color-choice
 - Useful for agent decision-making in models
 - Maintains conversation context
 
+### llm:chat-with-template
+
+**Syntax**: `llm:chat-with-template template-file variables`
+
+**Description**: Sends a prompt built from a YAML template file, substituting variables supplied from NetLogo. Keeps prompt wording out of the model code, so the phrasing can be changed and version-controlled without touching NetLogo source.
+
+**Parameters**:
+
+- `template-file` (string): Path to a YAML template
+- `variables` (list): List of `[key value]` pairs substituted into the template
+
+**Returns**: String — the model's response
+
+**The template file**:
+
+```yaml
+system: "You are a cautious forager deciding where to move next."
+template: |
+  You are at patch {xcor}, {ycor}.
+  Nearby food: {food-count}
+  Nearby predators: {predator-count}
+
+  Reply with exactly one of: MOVE, STAY, FLEE
+```
+
+`template` is required. `system` is optional — omit it and no system message is sent.
+
+**Using it from NetLogo**:
+
+```netlogo
+ask turtles [
+  let decision llm:chat-with-template "forager.yaml" (list
+    (list "xcor" xcor)
+    (list "ycor" ycor)
+    (list "food-count" count food-here)
+    (list "predator-count" count predators in-radius 3))
+
+  if decision = "FLEE" [ rt 180 fd 2 ]
+]
+```
+
+Each `{name}` in the template is replaced by the value paired with `"name"`. Values are converted to strings, so numbers and booleans can be passed directly.
+
+**Notes**:
+
+- **File lookup order**: the directory of the open model first, then the path as given, then the current working directory. Keeping the template beside the `.nlogox` is the reliable option — a bare working-directory path breaks when the model is opened from elsewhere.
+- A placeholder with no matching variable is left in the prompt as literal text (`{food-count}`), rather than raising. Worth checking the wording if a response looks confused.
+- The system message is prepended for this call only; it is not written into the agent's history.
+- The rendered prompt and the response are both committed to the agent's history on success, so `llm:chat` afterwards continues the same conversation. Nothing is committed if the call fails.
+- A missing file or a template without a `template:` field raises an extension error naming the file.
+
+**Example templates** ship in `demos/templates/` — `simple-template.yaml`, `reasoning-template.yaml`, `analysis-template.yaml`, `code-evolution-template.yaml`, and `movement-evolution.yaml`.
+
 ## Code Validation
 
 ### llm:compile-error

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -13,7 +13,7 @@ The NetLogo Multi-LLM Extension provides a unified interface for multiple Large 
 | `llm:chat-with-template file vars` | Chat          | Send templated prompt with variable substitution           |
 | `llm:chat-with-thinking text`      | Chat          | Returns `[answer thinking]` for reasoning-capable models   |
 | `llm:choose prompt choices`        | Chat          | Force selection from provided options                      |
-| `llm:compile-error code`           | Validation    | `""` if the code compiles, else the compiler error         |
+| `llm:compile-error code`           | Validation    | `""` if valid, else compiler error; optional disallowed list |
 | `llm:set-thinking bool`            | Reasoning     | Enable/disable reasoning mode for current provider         |
 | `llm:set-reasoning-effort level`   | Reasoning     | Set effort: `"low"`, `"medium"`, `"high"`                  |
 | `llm:set-thinking-budget n`        | Reasoning     | Token budget for thinking (min 1024; Anthropic + Gemini)   |
@@ -241,10 +241,11 @@ set color read-from-string color-choice
 ### llm:compile-error
 
 **Syntax**: `llm:compile-error code-string`
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`(llm:compile-error code-string disallowed-list)`
 
-**Description**: Checks whether a string of NetLogo commands compiles, without running it. Intended for validating LLM-generated code before `run`.
+**Description**: Checks whether a string of NetLogo commands compiles, without running it. Intended for validating LLM-generated code before `run`. With the optional second argument, also rejects code that uses any listed primitive.
 
-**Returns**: String — `""` if the code compiles, otherwise the compiler's error message with a character offset.
+**Returns**: String — `""` if the code is acceptable, otherwise a message explaining why not.
 
 **Example**:
 
@@ -256,12 +257,23 @@ ifelse llm:compile-error new-rule = ""
   [ print (word "Rejected: " llm:compile-error new-rule) ]
 ```
 
+With a disallowed list — note the parentheses, required when passing the optional argument:
+
+```netlogo
+let banned ["die" "clear-all" "ask" "hatch"]
+
+ifelse (llm:compile-error new-rule banned) = ""
+  [ run new-rule ]
+  [ print (llm:compile-error new-rule banned) ]
+```
+
 Typical error strings:
 
 ```
 Nothing named WEIGHT has been defined. (offset 76)
 FD expected 1 input, a number. (offset 73)
 Expected a TRUE/FALSE here, rather than a list or block. (offset 30)
+Disallowed primitive(s) used: die, clear-all
 ```
 
 **Notes**:
@@ -277,6 +289,19 @@ Expected a TRUE/FALSE here, rather than a list or block. (offset 30)
 - **Compiling is not the same as running safely.** Runtime errors — for example
   `item 3` on a three-element list — surface only during execution. Keep `carefully`
   around `run`.
+
+**The disallowed list**:
+
+- Checked only if the code compiles. Code that fails to compile cannot run, so its
+  syntax error is reported instead.
+- Matching is on **exact tokens**, using NetLogo's own tokenizer. Banning `"die"`
+  rejects `die` but not a variable named `diehard`, not `die` inside a comment, and
+  not the string `"die"`. Substring matching would reject all three, and a false
+  positive discards code that was valid.
+- Case-insensitive on both sides: `"DIE"` in the list matches `die` in the code.
+- The list is entirely caller-supplied. The extension ships no built-in set, because
+  what counts as dangerous is model-specific — a model may legitimately need `hatch`
+  while forbidding it in generated agent rules.
 
 **Enforcing your own policy**: this primitive checks syntax only. Domain rules stay in
 NetLogo, where you can change them without rebuilding the extension:

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -290,6 +290,27 @@ Disallowed primitive(s) used: die, clear-all
   `item 3` on a three-element list — surface only during execution. Keep `carefully`
   around `run`.
 
+**Multi-line code**:
+
+The whole string is compiled as one command block, so newlines, indentation and
+comments are all fine, and `let` variables defined on one line are in scope on later
+lines:
+
+```netlogo
+llm:compile-error "let x 5\nlet y x * 2\nrt y\nfd 1"   ;=> ""
+```
+
+Because it is a single block, ordinary scoping rules apply and their violations are
+reported:
+
+```netlogo
+llm:compile-error "fd x\nlet x 5"
+;=> "Nothing named X has been defined. (offset 3)"     - used before definition
+
+llm:compile-error "let x 5\nlet x 6\nfd x"
+;=> "There is already a local variable here called X (offset 43)"
+```
+
 **The disallowed list**:
 
 - Checked only if the code compiles. Code that fails to compile cannot run, so its

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -13,6 +13,7 @@ The NetLogo Multi-LLM Extension provides a unified interface for multiple Large 
 | `llm:chat-with-template file vars` | Chat          | Send templated prompt with variable substitution           |
 | `llm:chat-with-thinking text`      | Chat          | Returns `[answer thinking]` for reasoning-capable models   |
 | `llm:choose prompt choices`        | Chat          | Force selection from provided options                      |
+| `llm:compile-error code`           | Validation    | `""` if the code compiles, else the compiler error         |
 | `llm:set-thinking bool`            | Reasoning     | Enable/disable reasoning mode for current provider         |
 | `llm:set-reasoning-effort level`   | Reasoning     | Set effort: `"low"`, `"medium"`, `"high"`                  |
 | `llm:set-thinking-budget n`        | Reasoning     | Token budget for thinking (min 1024; Anthropic + Gemini)   |
@@ -234,6 +235,59 @@ set color read-from-string color-choice
 - Forces LLM to return exactly one of the provided choices
 - Useful for agent decision-making in models
 - Maintains conversation context
+
+## Code Validation
+
+### llm:compile-error
+
+**Syntax**: `llm:compile-error code-string`
+
+**Description**: Checks whether a string of NetLogo commands compiles, without running it. Intended for validating LLM-generated code before `run`.
+
+**Returns**: String — `""` if the code compiles, otherwise the compiler's error message with a character offset.
+
+**Example**:
+
+```netlogo
+let new-rule llm:chat "Write NetLogo commands to make this turtle seek food."
+
+ifelse llm:compile-error new-rule = ""
+  [ run new-rule ]
+  [ print (word "Rejected: " llm:compile-error new-rule) ]
+```
+
+Typical error strings:
+
+```
+Nothing named WEIGHT has been defined. (offset 76)
+FD expected 1 input, a number. (offset 73)
+Expected a TRUE/FALSE here, rather than a list or block. (offset 30)
+```
+
+**Notes**:
+
+- Uses NetLogo's own compiler — the same one `run` uses. If this returns a non-empty
+  string, `run` would have failed with that error.
+- Compiles in **turtle context**, because generated agent rules are normally executed
+  inside `ask turtles`. Turtle-only primitives such as `fd` and `rt` are therefore valid.
+- The **live model's symbol table is in scope** — `turtles-own` variables, globals, and
+  breeds defined by the running model all resolve. An external validator cannot do this,
+  which is why undefined-variable errors are the most common failure it catches.
+- Empty or whitespace-only input reports `""` (valid): empty commands are legal NetLogo.
+- **Compiling is not the same as running safely.** Runtime errors — for example
+  `item 3` on a three-element list — surface only during execution. Keep `carefully`
+  around `run`.
+
+**Enforcing your own policy**: this primitive checks syntax only. Domain rules stay in
+NetLogo, where you can change them without rebuilding the extension:
+
+```netlogo
+to-report acceptable? [ code ]
+  if llm:compile-error code != "" [ report false ]
+  if length code > 500 [ report false ]
+  report true
+end
+```
 
 ## Reasoning / Thinking Primitives
 

--- a/src/main/LLMExtension.scala
+++ b/src/main/LLMExtension.scala
@@ -102,6 +102,9 @@ class LLMExtension extends DefaultClassManager {
     manager.addPrimitive("chat-with-thinking", ChatWithThinkingReporter)
     manager.addPrimitive("choose", ChooseReporter)
 
+    // Code validation primitive
+    manager.addPrimitive("compile-error", CompileErrorReporter)
+
     // Thinking/reasoning configuration primitives
     manager.addPrimitive("set-thinking", SetThinkingCommand)
     manager.addPrimitive("set-reasoning-effort", SetReasoningEffortCommand)
@@ -710,8 +713,61 @@ class LLMExtension extends DefaultClassManager {
     }
   }
 
+  // Code Validation Primitive
+
+  /**
+   * Reports "" if the given string compiles as NetLogo turtle commands,
+   * otherwise the compiler's error message and character offset.
+   *
+   * This calls NetLogo's own compiler — the same one `run` uses — so a
+   * non-empty result guarantees `run` would have failed. There is no separate
+   * parser to drift out of sync with the language or with the model's symbol
+   * table: turtle-own variables, globals, and breeds defined by the running
+   * model are all in scope.
+   *
+   * Compiles in Turtle context because generated agent rules are executed
+   * inside `ask turtles`. Observer context would reject `fd`/`rt` and reject
+   * valid rules.
+   *
+   * Scope: this proves the code COMPILES, not that it cannot throw at runtime.
+   * Bounds errors such as `item 3` on a 3-element list still surface only when
+   * the code runs, so keep `carefully` around execution.
+   */
+  object CompileErrorReporter extends Reporter {
+    override def getSyntax: Syntax = Syntax.reporterSyntax(
+      right = List(Syntax.StringType),
+      ret = Syntax.StringType
+    )
+
+    override def report(args: Array[Argument], context: Context): AnyRef = {
+      val code = args(0).getString
+
+      // Empty or whitespace-only code is valid NetLogo — a no-op rule.
+      if (code.trim.isEmpty) return ""
+
+      val workspace = context match {
+        case ec: org.nlogo.nvm.ExtensionContext => ec.workspace
+        case _ =>
+          throw new ExtensionException(
+            "llm:compile-error requires a NetLogo workspace and is unavailable in this context"
+          )
+      }
+
+      try {
+        workspace.compileCommands(code, org.nlogo.core.AgentKind.Turtle)
+        ""
+      } catch {
+        case e: org.nlogo.core.CompilerException =>
+          s"${e.getMessage} (offset ${e.start})"
+        case e: Exception =>
+          // Never silently swallow an unexpected failure as "valid".
+          throw new ExtensionException(s"llm:compile-error failed: ${e.getMessage}")
+      }
+    }
+  }
+
   // History Management Primitives
-  
+
   object HistoryReporter extends Reporter {
     override def getSyntax: Syntax = Syntax.reporterSyntax(ret = Syntax.ListType)
     

--- a/src/main/LLMExtension.scala
+++ b/src/main/LLMExtension.scala
@@ -717,7 +717,14 @@ class LLMExtension extends DefaultClassManager {
 
   /**
    * Reports "" if the given string compiles as NetLogo turtle commands,
-   * otherwise the compiler's error message and character offset.
+   * otherwise a message describing why it is unacceptable.
+   *
+   *   llm:compile-error code
+   *   (llm:compile-error code ["die" "clear-all"])
+   *
+   * The optional second argument is a list of primitive names that must not
+   * appear in the code. It is caller-supplied policy, not a built-in list:
+   * what counts as dangerous depends on the model.
    *
    * This calls NetLogo's own compiler — the same one `run` uses — so a
    * non-empty result guarantees `run` would have failed. There is no separate
@@ -735,8 +742,9 @@ class LLMExtension extends DefaultClassManager {
    */
   object CompileErrorReporter extends Reporter {
     override def getSyntax: Syntax = Syntax.reporterSyntax(
-      right = List(Syntax.StringType),
-      ret = Syntax.StringType
+      right = List(Syntax.StringType, Syntax.ListType | Syntax.RepeatableType),
+      ret = Syntax.StringType,
+      defaultOption = Some(1)
     )
 
     override def report(args: Array[Argument], context: Context): AnyRef = {
@@ -753,16 +761,43 @@ class LLMExtension extends DefaultClassManager {
           )
       }
 
+      // Syntax first. Code that does not compile cannot run, so a banned-primitive
+      // report would be noise — and tokenizing malformed code is unreliable anyway.
       try {
         workspace.compileCommands(code, org.nlogo.core.AgentKind.Turtle)
-        ""
       } catch {
         case e: org.nlogo.core.CompilerException =>
-          s"${e.getMessage} (offset ${e.start})"
+          return s"${e.getMessage} (offset ${e.start})"
         case e: Exception =>
           // Never silently swallow an unexpected failure as "valid".
           throw new ExtensionException(s"llm:compile-error failed: ${e.getMessage}")
       }
+
+      if (args.length < 2) return ""
+
+      val banned = args(1).getList.toVector.collect {
+        case s: String => s.trim.toLowerCase
+      }.filter(_.nonEmpty)
+
+      if (banned.isEmpty) return ""
+
+      // Exact token match using NetLogo's own tokenizer. Substring matching would
+      // flag `die` inside `diehard`, inside a comment, or inside a string literal —
+      // false positives that would reject valid code.
+      val found =
+        try {
+          org.nlogo.lex.Tokenizer.tokenizeString(code, "")
+            .map(_.text.toLowerCase)
+            .filter(banned.contains)
+            .toVector
+            .distinct
+        } catch {
+          case e: Exception =>
+            throw new ExtensionException(s"llm:compile-error failed while scanning: ${e.getMessage}")
+        }
+
+      if (found.isEmpty) ""
+      else s"Disallowed primitive(s) used: ${found.mkString(", ")}"
     }
   }
 

--- a/src/main/LLMExtension.scala
+++ b/src/main/LLMExtension.scala
@@ -775,9 +775,20 @@ class LLMExtension extends DefaultClassManager {
 
       if (args.length < 2) return ""
 
-      val banned = args(1).getList.toVector.collect {
-        case s: String => s.trim.toLowerCase
-      }.filter(_.nonEmpty)
+      val rawList = args(1).getList.toVector
+
+      // Reject a malformed list rather than silently ignoring it. Skipping
+      // non-strings would report "" — a false all-clear — for a caller who
+      // passed the wrong thing.
+      val nonStrings = rawList.filterNot(_.isInstanceOf[String])
+      if (nonStrings.nonEmpty) {
+        throw new ExtensionException(
+          "llm:compile-error expects a list of primitive names as strings, but got: " +
+            nonStrings.map(v => Dump.logoObject(v)).mkString(", ")
+        )
+      }
+
+      val banned = rawList.map(_.asInstanceOf[String].trim.toLowerCase).filter(_.nonEmpty)
 
       if (banned.isEmpty) return ""
 

--- a/tests.txt
+++ b/tests.txt
@@ -404,3 +404,67 @@ LLMCompileErrorSyntaxBeforeBanned
   extensions [llm]
   (llm:compile-error "frobnicate die" ["die"]) != "" => true
   member? "Disallowed" (llm:compile-error "frobnicate die" ["die"]) => false
+
+LLMCompileErrorMultiLineLocals
+  extensions [llm]
+  llm:compile-error "let x 5\nfd x" => ""
+  llm:compile-error "let x 5\nlet y x * 2\nrt y\nfd 1" => ""
+  llm:compile-error "let x 5\n\n  rt x\n  fd 1\n" => ""
+  llm:compile-error "let d 3\nifelse d > 2\n  [ fd d ]\n  [ rt 90 fd 1 ]" => ""
+  llm:compile-error "  \n  fd 1  \n  " => ""
+  llm:compile-error "let x 1 let y 2 let z 3 fd x + y + z" => ""
+  (llm:compile-error "let x 5\nfd undefined-thing") != "" => true
+  (llm:compile-error "fd x\nlet x 5") != "" => true
+  (llm:compile-error "let x 5\nlet x 6\nfd x") != "" => true
+  (llm:compile-error "let x 5\nlet x 6\nfd x") => "There is already a local variable here called X (offset 43)"
+
+LLMCompileErrorTurtleOwnVariables
+  extensions [llm]
+  llm:compile-error "fd xcor" => ""
+  llm:compile-error "set heading heading + 10 fd 1" => ""
+  llm:compile-error "ifelse pcolor = green [ fd 1 ] [ rt 90 ]" => ""
+  llm:compile-error "let n count turtles in-radius 3\nfd n" => ""
+  (llm:compile-error "fd not-a-turtle-variable") != "" => true
+
+LLMCompileErrorComments
+  extensions [llm]
+  llm:compile-error "; only a comment" => ""
+  llm:compile-error "fd 1 ; move forward" => ""
+  llm:compile-error "; leading comment\nfd 1\n; trailing comment" => ""
+  llm:compile-error "let x 5 ; set speed\nfd x" => ""
+
+LLMCompileErrorNestedAndBlocks
+  extensions [llm]
+  llm:compile-error "ask other turtles in-radius 2 [ rt 180 ]" => ""
+  llm:compile-error "repeat 3 [ fd 1 rt 120 ]" => ""
+  llm:compile-error "if any? other turtles [ fd 1 ]" => ""
+  llm:compile-error "(ifelse xcor > 5 [ rt 90 ] xcor < -5 [ lt 90 ] [ fd 1 ])" => ""
+  llm:compile-error "foreach [1 2 3] [ n -> fd n ]" => ""
+  (llm:compile-error "repeat 3 [ fd 1 rt 120") != "" => true
+  (llm:compile-error "ask turtles [ fd 1 ] ]") != "" => true
+
+LLMCompileErrorBannedMultiLine
+  extensions [llm]
+  (llm:compile-error "let x 5\nfd x\ndie" ["die"]) => "Disallowed primitive(s) used: die"
+  (llm:compile-error "fd 1\n; die here is a comment\nrt 90" ["die"]) => ""
+  (llm:compile-error "ask turtles [ die ]" ["die"]) => "Disallowed primitive(s) used: die"
+  (llm:compile-error "fd 1\nrt 90" ["die" "clear-all" "hatch"]) => ""
+  (llm:compile-error "let diehard 1\nfd diehard" ["die"]) => ""
+
+LLMCompileErrorBannedMultipleFound
+  extensions [llm]
+  (llm:compile-error "ask turtles [ die ]" ["die" "ask"]) => "Disallowed primitive(s) used: ask, die"
+  (llm:compile-error "die die die" ["die"]) => "Disallowed primitive(s) used: die"
+
+LLMCompileErrorBannedEdgeCases
+  extensions [llm]
+  (llm:compile-error "" ["die"]) => ""
+  (llm:compile-error "fd 1" ["  "]) => ""
+  (llm:compile-error "fd 1" ["fd"]) => "Disallowed primitive(s) used: fd"
+  (llm:compile-error "fd 1" ["  die  "]) => ""
+  (llm:compile-error "die" ["  die  "]) => "Disallowed primitive(s) used: die"
+
+LLMCompileErrorBannedListValidation
+  extensions [llm]
+  (llm:compile-error "die" [1 2]) => ERROR Extension exception: llm:compile-error expects a list of primitive names as strings, but got: 1, 2
+  (llm:compile-error "fd 1" ["die" 5]) => ERROR Extension exception: llm:compile-error expects a list of primitive names as strings, but got: 5

--- a/tests.txt
+++ b/tests.txt
@@ -384,3 +384,23 @@ LLMCompileErrorLEARCorpus
   llm:compile-error "ifelse random 2 = 0 [lt random-float 10 fd 1] [rt random-float 10 fd 1]" => ""
   llm:compile-error "ifelse random 2 = 0 [ fd 1 ] [ ifelse random 2 = 1 [ rt 10 fd 1 ] [ lt 10 fd 1 ] ]" => ""
   llm:compile-error "ifelse random-float 1 < 0.4 [lt random 10 fd 1] [ifelse random-float 1 < 0.3 [rt random 10 fd 1] [fd 1] ]" => ""
+
+LLMCompileErrorBannedPrimitives
+  extensions [llm]
+  (llm:compile-error "fd 1" ["die"]) => ""
+  (llm:compile-error "fd 1" []) => ""
+  (llm:compile-error "die" ["die"]) => "Disallowed primitive(s) used: die"
+  (llm:compile-error "fd 1 die" ["die" "clear-all"]) => "Disallowed primitive(s) used: die"
+  (llm:compile-error "DIE" ["die"]) => "Disallowed primitive(s) used: die"
+  (llm:compile-error "die" ["DIE"]) => "Disallowed primitive(s) used: die"
+
+LLMCompileErrorBannedNoFalsePositives
+  extensions [llm]
+  (llm:compile-error "fd 1 ; die is banned" ["die"]) => ""
+  (llm:compile-error "let diehard 1 fd diehard" ["die"]) => ""
+  (llm:compile-error "print \"die\"" ["die"]) => ""
+
+LLMCompileErrorSyntaxBeforeBanned
+  extensions [llm]
+  (llm:compile-error "frobnicate die" ["die"]) != "" => true
+  member? "Disallowed" (llm:compile-error "frobnicate die" ["die"]) => false

--- a/tests.txt
+++ b/tests.txt
@@ -343,3 +343,44 @@ LLMMixedSyncAsyncHistoryAtomic
   (item 0 (item 1 h)) => "assistant"
   (item 0 (item 2 h)) => "user"
   (item 0 (item 3 h)) => "assistant"
+
+LLMCompileErrorValid
+  extensions [llm]
+  llm:compile-error "fd 1" => ""
+  llm:compile-error "rt 90 fd 1" => ""
+  llm:compile-error "" => ""
+  llm:compile-error "   " => ""
+  llm:compile-error "ifelse xcor > 0 [ fd 1 ] [ bk 1 ]" => ""
+  llm:compile-error "rt (random 90) * 0.5 + (random 45) * 0.5" => ""
+
+LLMCompileErrorInvalid
+  extensions [llm]
+  (llm:compile-error "frobnicate") != "" => true
+  (llm:compile-error "fd") != "" => true
+  (llm:compile-error "if xcor > 0 [fd 1] [bk 1]") != "" => true
+  (llm:compile-error "ifelse xcor > 0 [ fd 1 ]") != "" => true
+  (llm:compile-error "rt undefined-var-xyz") != "" => true
+  is-string? (llm:compile-error "frobnicate") => true
+
+LLMCompileErrorTurtleContext
+  extensions [llm]
+  llm:compile-error "set heading 90" => ""
+  llm:compile-error "set color red fd 1" => ""
+
+
+LLMCompileErrorLEARCorpus
+  extensions [llm]
+  llm:compile-error "ifelse random 2 < 1 [lt 10 fd 1] [ifelse random 2 < 1 [rt 10 fd 1] [fd 1] ]" => ""
+  llm:compile-error "ifelse random 2 = 0 [ lt random 20 fd 1 ] [ rt random 20 fd 1 ]" => ""
+  llm:compile-error "ifelse random 2 = 0 [fd 1] [rt 90 fd 1]" => ""
+  llm:compile-error "ifelse random 2 = 0 [lt random 10 fd 1] [rt random 10 fd 1]" => ""
+  llm:compile-error "ifelse random 2 = 0 [lt random 20 fd 1] [rt random 10 fd 1]" => ""
+  llm:compile-error "ifelse random 2 = 0 [lt random 30 fd 1] [rt random 30 fd 1]" => ""
+  llm:compile-error "ifelse random 2 = 0 [rt random 30 fd 1] [lt random 30 fd 1]" => ""
+  llm:compile-error "ifelse random 2 = 0 [ifelse random 2 = 0 [lt 10 fd 1] [rt 10 fd 1]] [ifelse random 2 = 0 [lt random 10 fd 1] [rt random 10 fd 1]]" => ""
+  llm:compile-error "ifelse random 2 = 0 [lt random 10 fd 1] [ifelse random 2 = 0 [rt random 10 fd 1] [fd 1] ]" => ""
+  llm:compile-error "ifelse random 2 = 0 [lt random 10 fd 1] [ifelse random 2 = 1 [rt random 10 fd 1] [fd 1] ]" => ""
+  llm:compile-error "ifelse random 2 = 0 [lt random 20 fd 1] [rt random 20 fd 1]" => ""
+  llm:compile-error "ifelse random 2 = 0 [lt random-float 10 fd 1] [rt random-float 10 fd 1]" => ""
+  llm:compile-error "ifelse random 2 = 0 [ fd 1 ] [ ifelse random 2 = 1 [ rt 10 fd 1 ] [ lt 10 fd 1 ] ]" => ""
+  llm:compile-error "ifelse random-float 1 < 0.4 [lt random 10 fd 1] [ifelse random-float 1 < 0.3 [rt random 10 fd 1] [fd 1] ]" => ""


### PR DESCRIPTION
Closes #52 (roadmap B3).

## Why

Several demos use the "LLM writes NetLogo code, the model runs it" pattern (`demos/templates/code-evolution-template.yaml`, `movement-evolution.yaml`). Today generated code goes straight to `run`/`runresult` with no checks: invalid code throws mid-tick, and nothing stops a model from emitting `clear-all` or `die`.

This adds the gate that makes that pattern safe enough to put in front of students.

## What

A single reporter, `llm:compile-error`, returning `""` when code is acceptable and an explanatory message otherwise.

```netlogo
llm:compile-error "fd 1"        ;=> ""
llm:compile-error "frobnicate"  ;=> "Nothing named FROBNICATE has been defined. (offset 0)"

(llm:compile-error code ["die" "clear-all"])
;=> "Disallowed primitive(s) used: die"
```

Plus a demo model, `demos/code-validation/`, exercising it end to end.

## Design decisions

**Uses NetLogo's own compiler**, reached via `ExtensionContext` -> `workspace.compileCommands`. This answers the issue's first open question: an extension *can* compile arbitrary source without a full workspace round-trip. It also means the live model's symbol table is in scope, so `turtles-own` variables, globals, and breeds resolve — an external validator cannot do this, and undefined-variable errors are the most common failure caught.

**Compiles in turtle context**, because generated agent rules are normally executed inside `ask turtles`. Observer context would reject `fd`/`rt` and refuse valid rules.

**Syntax is checked first and returns early.** Code that does not compile cannot run, so reporting banned primitives on it would be noise — and tokenizing malformed code is unreliable.

**Banned-primitive matching is on exact tokens** via NetLogo's tokenizer, not substrings. Banning `die` rejects `die` but not `diehard`, not `die` in a comment, and not the string `"die"`. Substring matching produced all three false positives, and a false positive discards code that was valid.

**No built-in banned set ships.** What counts as dangerous is model-specific — a model may legitimately need `hatch` while forbidding it in generated rules. The issue suggested a default list; this was deliberately not taken, so policy stays in NetLogo where it can change without rebuilding the extension.

**A malformed list is rejected rather than ignored.** `(llm:compile-error "die" [1 2])` previously returned `""` — a false all-clear for a caller who passed the wrong thing. It now raises.

## Scope

This proves code **compiles**, not that it cannot throw at runtime. Bounds errors such as `item 3` on a three-element list still surface only during execution, so `carefully` around `run` is still needed. Documented in the API reference.

## Demo

`demos/code-validation/code-validation.nlogox` — each turtle draws a candidate rule from a pool and adopts it only if the gate returns `""`. Accepted turtles turn green; refused ones keep their previous rule and turn red.

The pool deliberately mixes valid rules, rules that fail to compile (`frobnicate 1`, an unbalanced `ifelse`), and rules that compile but are banned (`die`, `ask turtles [ fd 1 ]`) — so both failure modes are visible on every run. A **check all rules** button prints the verdict for each candidate.

Candidates are a fixed list rather than `llm:chat`, so **the demo runs with no API key**; swapping in `llm:chat` is the only change needed to make it live. Includes a README and a full info tab.

## Tests

`sbt test` — **54 passing, 0 failed**. 15 new blocks in `tests.txt` (~94 assertions):

- valid / invalid code, turtle context, multi-line `let` scoping, comments, nested blocks
- a 14-rule corpus of real evolved rules from the LEAR project, as a false-negative regression guard
- banned primitives: hit/miss, case-insensitivity both directions, dedup, multi-line
- the three false-positive cases (comment, identifier, string literal)
- ordering (syntax error wins over banned report) and malformed-list rejection

The demo model additionally passes a headless compile check with zero style findings.

## Follow-ups, not in this PR

- The default-banned-list question, if a sane default turns out to be wanted after real use
